### PR TITLE
Update scheme

### DIFF
--- a/lib/omniauth-figshare/version.rb
+++ b/lib/omniauth-figshare/version.rb
@@ -2,7 +2,7 @@ module OmniAuth
   module Figshare
     VERSION_MAJOR = 0
     VERSION_MINOR = 1
-    VERSION_PATCH = 0
+    VERSION_PATCH = 1
     VERSION = [VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH].join('.')
   end
 end

--- a/lib/omniauth/strategies/figshare.rb
+++ b/lib/omniauth/strategies/figshare.rb
@@ -26,7 +26,7 @@ module OmniAuth
       option :name, 'figshare'
       
       option :client_options, {
-        :site => 'http://api.figshare.com/v1/pbl'
+        :site => 'https://api.figshare.com/v1/pbl'
       }
 
       uid {

--- a/omniauth-figshare.gemspec
+++ b/omniauth-figshare.gemspec
@@ -15,9 +15,9 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = 'omniauth-figshare'
 
-  s.add_runtime_dependency 'omniauth-oauth', '~> 1.0.1'
-  s.add_runtime_dependency 'multi_json', '~> 1.9.3'
-  s.add_development_dependency 'gemma', '~> 4.1'
+  s.add_runtime_dependency 'omniauth-oauth'
+  s.add_runtime_dependency 'multi_json'
+  s.add_development_dependency 'gemma'
 
   s.files       = Dir.glob('{lib,bin}/**/*.rb') + %w(README.rdoc)
   s.test_files  = Dir.glob('test/omniauth-figshare/*_test.rb')


### PR DESCRIPTION
- Figshare's client endpoint is now `HTTPS`
- removed version specifier on dependencies (unless this was here for a specific reason I missed?)
- version is now `0.1.1`
